### PR TITLE
Fix wrong cached languages leaking to clients:

### DIFF
--- a/scripting/killer_info_display.sp
+++ b/scripting/killer_info_display.sp
@@ -229,6 +229,8 @@ public Action:Event_PlayerDeath(Handle:event, const String:name[], bool:dontBroa
 	GetEventString(event, "weapon", weapon, sizeof(weapon));		
 	GetConVarString(cvDistancetype, distanceType, sizeof(distanceType));
 
+	SetGlobalTransTarget(client);
+
 	if (showArmorLeft > 0) {
 
 		if (showArmorLeft == 1) {
@@ -399,6 +401,8 @@ DisplaySettingsMenu(client)
 {
 	decl String:MenuItem[128];
 	new Handle:prefmenu = CreateMenu(PrefMenuHandler);
+
+	SetGlobalTransTarget(client);
 
 	Format(MenuItem, sizeof(MenuItem), "%t", "name");
 	SetMenuTitle(prefmenu, MenuItem);


### PR DESCRIPTION
Fixes cases where client messages may employ a language that doesn't correspond to the target, caused by languages from other clients being leftover in the global cache and plugin not (re)setting correct language during formatting. This fixes the issue via SetGlobalTransTarget method.